### PR TITLE
Fix dark mode typography not working (#30)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
+const selectorParser = require('postcss-selector-parser');
+
 module.exports = function() {
   return function({addVariant, theme, e}) {
     const darkSelector = theme('darkSelector', '.mode-dark');
-    addVariant('dark', ({modifySelectors, separator}) => {
-      modifySelectors(({className}) => {
-        return `${darkSelector} .${e(`dark${separator}${className}`)}, ${darkSelector}.${e(`dark${separator}${className}`)}`;
+
+    addVariant('dark', ({ modifySelectors, separator }) => {
+      modifySelectors(({ selector }) => {
+        return selectorParser((selectors) => {
+          selectors.walkClasses((sel) => {
+            sel.value = `dark${separator}${sel.value}`;
+            sel.parent.insertBefore(sel, selectorParser().astSync(prefix(`${darkSelector} `)));
+          });
+        }).processSync(selector);
       });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-dark-mode",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "javascript"
   ],
   "dependencies": {
-    "tailwindcss": "^1.6.2"
+    "tailwindcss": "^1.6.2",
+    "postcss-selector-parser": "^6.0.2"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
Fix #30 

Add Adam Wathan's dark mode variant can working on typography. This dark mode variant base features the same this tailwindcss-dark-mode package.

> Reference tailwindcss-dark-mode-prototype for Adam Wathan https://github.com/adamwathan/tailwindcss-dark-mode-prototype