### PR TITLE
Add 'hover' to tailwind.config.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ As with existing variants such as `hover` and `focus`, variants for dark mode mu
 
 ```javascript
 variants: {
-  backgroundColor: ['dark', 'dark-hover', 'dark-group-hover', 'dark-even', 'dark-odd'],
-  borderColor: ['dark', 'dark-disabled', 'dark-focus', 'dark-focus-within'],
-  textColor: ['dark', 'dark-hover', 'dark-active', 'dark-placeholder']
+  backgroundColor: ['dark', 'dark-hover', 'dark-group-hover', 'dark-even', 'dark-odd', 'hover'],
+  borderColor: ['dark', 'dark-disabled', 'dark-focus', 'dark-focus-within', 'hover'],
+  textColor: ['dark', 'dark-hover', 'dark-active', 'dark-placeholder', 'hover']
 }
 ```
 


### PR DESCRIPTION
if you don't add hover, all existing hover effects break. See https://github.com/ChanceArthur/tailwindcss-dark-mode/issues/39